### PR TITLE
Add weapon picker

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -225,10 +225,10 @@ export default function App() {
           return acc.set(weapon.weaponName, weapon);
         }, new Map<string, Weapon>())
         .values(),
-    ];
+    ].filter((weapon) => (includeDLC ? true : !weapon.dlc));
 
     return makeWeaponOptionsFromWeapon(dedupedWeaponsByWeaponName);
-  }, [weapons]);
+  }, [weapons, includeDLC]);
 
   const drawerContent = (
     <>
@@ -243,15 +243,15 @@ export default function App() {
         onIncludeDLCChanged={setIncludeDLC}
         onEffectiveOnlyChanged={setEffectiveOnly}
       />
-      <AffinityPicker
-        affinityOptions={regulationVersion.affinityOptions}
-        selectedAffinityIds={affinityIds}
-        onAffinityIdsChanged={setAffinityIds}
-      />
       <WeaponPicker
         selectedWeapons={selectedWeapons}
         onSelectedWeaponsChanged={setSelectedWeapons}
         weaponOptions={weaponPickerOptions}
+      />
+      <AffinityPicker
+        affinityOptions={regulationVersion.affinityOptions}
+        selectedAffinityIds={affinityIds}
+        onAffinityIdsChanged={setAffinityIds}
       />
       <WeaponTypePicker
         includeDLCWeaponTypes={canIncludeDLCWeaponTypes}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -28,6 +28,8 @@ import WeaponTypePicker from "./WeaponTypePicker";
 import AffinityPicker from "./AffinityPicker";
 import Footer from "./Footer";
 import MiscFilterPicker from "./MiscFilterPicker";
+import WeaponPicker, { makeWeaponOptionsFromWeapon } from "./WeaponPicker";
+import type { Weapon } from "../calculator/weapon";
 
 const useMenuState = () => {
   const theme = useTheme();
@@ -112,6 +114,7 @@ export default function App() {
     numericalScaling,
     sortBy,
     reverse,
+    selectedWeapons,
     setRegulationVersionName,
     setAffinityIds,
     setWeaponTypes,
@@ -125,6 +128,7 @@ export default function App() {
     setNumericalScaling,
     setSortBy,
     setReverse,
+    setSelectedWeapons,
   } = useAppState();
 
   const { isMobile, menuOpen, menuOpenMobile, onMenuOpenChanged } = useMenuState();
@@ -151,6 +155,7 @@ export default function App() {
     twoHanding,
     upgradeLevel,
     groupWeaponTypes,
+    selectedWeapons,
   });
 
   const tablePlaceholder = useMemo(
@@ -213,6 +218,18 @@ export default function App() {
   const canIncludeDLCWeaponTypes =
     (regulationVersionName === "latest" && includeDLC) || regulationVersionName === "convergence";
 
+  const weaponPickerOptions = useMemo(() => {
+    const dedupedWeaponsByWeaponName = [
+      ...weapons
+        .reduce((acc, weapon) => {
+          return acc.set(weapon.weaponName, weapon);
+        }, new Map<string, Weapon>())
+        .values(),
+    ];
+
+    return makeWeaponOptionsFromWeapon(dedupedWeaponsByWeaponName);
+  }, [weapons]);
+
   const drawerContent = (
     <>
       <RegulationVersionPicker
@@ -230,6 +247,11 @@ export default function App() {
         affinityOptions={regulationVersion.affinityOptions}
         selectedAffinityIds={affinityIds}
         onAffinityIdsChanged={setAffinityIds}
+      />
+      <WeaponPicker
+        selectedWeapons={selectedWeapons}
+        onSelectedWeaponsChanged={setSelectedWeapons}
+        weaponOptions={weaponPickerOptions}
       />
       <WeaponTypePicker
         includeDLCWeaponTypes={canIncludeDLCWeaponTypes}

--- a/src/app/WeaponPicker.tsx
+++ b/src/app/WeaponPicker.tsx
@@ -1,0 +1,65 @@
+import { Autocomplete, Box, TextField, Typography } from "@mui/material";
+import { memo, useCallback, useMemo } from "react";
+import type { Weapon } from "../calculator/weapon";
+import { weaponTypeLabels } from "./uiUtils";
+
+export type WeaponOption = {
+  label: string; // weaponName
+  value: string; // weaponName
+  type: string; // weaponType
+};
+
+interface Props {
+  selectedWeapons: WeaponOption[];
+  onSelectedWeaponsChanged(weapons: WeaponOption[]): void;
+  weaponOptions: WeaponOption[];
+}
+
+const sortByTypeThenName = (a: Weapon, b: Weapon): number => {
+  if (a.weaponType < b.weaponType) return -1;
+  if (a.weaponType > b.weaponType) return 1;
+  // weapon types are the same, so compare the name
+  if (a.weaponName < b.weaponName) return -1;
+  if (a.weaponName > b.weaponName) return 1;
+  // both primary and secondary values are equal
+  return 0;
+};
+const makeOption = (weapon: Weapon): WeaponOption => ({
+  label: weapon.weaponName,
+  value: weapon.weaponName,
+  type: weaponTypeLabels.get(weapon.weaponType) || "",
+});
+
+export const makeWeaponOptionsFromWeapon = (weapons: Weapon[]): WeaponOption[] =>
+  weapons.sort(sortByTypeThenName).map(makeOption);
+
+/**
+ * An Autocomplete to allow for manually specifying weapons
+ */
+function WeaponPicker({ onSelectedWeaponsChanged, weaponOptions, selectedWeapons }: Props) {
+  const handleOnChange = useCallback(
+    (event: React.SyntheticEvent<Element, Event>, newSelection: WeaponOption[]) => {
+      onSelectedWeaponsChanged(newSelection);
+    },
+    [onSelectedWeaponsChanged],
+  );
+
+  return (
+    <Box>
+      <Typography component="h2" variant="h6" sx={{ mb: 1 }}>
+        Weapons
+      </Typography>
+      <Autocomplete
+        multiple
+        options={weaponOptions}
+        value={selectedWeapons}
+        onChange={handleOnChange}
+        renderInput={(params) => <TextField {...params} label="Weapons" />}
+        groupBy={(weapon) => weapon.type}
+        size="small"
+      />
+    </Box>
+  );
+}
+
+export default memo(WeaponPicker);

--- a/src/app/WeaponPicker.tsx
+++ b/src/app/WeaponPicker.tsx
@@ -1,5 +1,5 @@
-import { Autocomplete, Box, TextField, Typography } from "@mui/material";
-import { memo, useCallback, useMemo } from "react";
+import { Autocomplete, Box, TextField } from "@mui/material";
+import { memo, useCallback } from "react";
 import type { Weapon } from "../calculator/weapon";
 import { weaponTypeLabels } from "./uiUtils";
 
@@ -46,9 +46,6 @@ function WeaponPicker({ onSelectedWeaponsChanged, weaponOptions, selectedWeapons
 
   return (
     <Box>
-      <Typography component="h2" variant="h6" sx={{ mb: 1 }}>
-        Weapons
-      </Typography>
       <Autocomplete
         multiple
         options={weaponOptions}

--- a/src/app/useAppState.ts
+++ b/src/app/useAppState.ts
@@ -4,6 +4,7 @@ import type { SortBy } from "../search/sortWeapons";
 import type { RegulationVersionName } from "./regulationVersions";
 import regulationVersions from "./regulationVersions";
 import { dlcWeaponTypes } from "./uiUtils";
+import { type WeaponOption } from "./WeaponPicker";
 
 interface AppState {
   readonly regulationVersionName: RegulationVersionName;
@@ -19,6 +20,7 @@ interface AppState {
   readonly numericalScaling: boolean;
   readonly sortBy: SortBy;
   readonly reverse: boolean;
+  readonly selectedWeapons: WeaponOption[];
 }
 
 interface UpdateAppState extends AppState {
@@ -35,6 +37,7 @@ interface UpdateAppState extends AppState {
   setNumericalScaling(numericalScaling: boolean): void;
   setSortBy(sortBy: SortBy): void;
   setReverse(reverse: boolean): void;
+  setSelectedWeapons(weapons: WeaponOption[]): void;
 }
 
 const defaultAppState: AppState = {
@@ -57,6 +60,7 @@ const defaultAppState: AppState = {
   numericalScaling: false,
   sortBy: "totalAttack",
   reverse: false,
+  selectedWeapons: [],
 };
 
 /**
@@ -169,6 +173,9 @@ export default function useAppState() {
       },
       setReverse(reverse) {
         setAppState((prevAppState) => ({ ...prevAppState, reverse }));
+      },
+      setSelectedWeapons(selectedWeapons) {
+        setAppState((prevAppState) => ({ ...prevAppState, selectedWeapons }));
       },
     }),
     [],

--- a/src/app/weaponTable/useWeaponTableRows.tsx
+++ b/src/app/weaponTable/useWeaponTableRows.tsx
@@ -16,6 +16,7 @@ import {
   maxSpecialUpgradeLevel,
   toSpecialUpgradeLevel,
 } from "../uiUtils";
+import type { WeaponOption } from "../WeaponPicker";
 
 interface WeaponTableRowsOptions {
   weapons: readonly Weapon[];
@@ -32,6 +33,7 @@ interface WeaponTableRowsOptions {
   twoHanding: boolean;
   upgradeLevel: number;
   groupWeaponTypes: boolean;
+  selectedWeapons: WeaponOption[];
 }
 
 interface WeaponTableRowsResult {
@@ -68,6 +70,7 @@ const useWeaponTableRows = ({
   const affinityIds = useDeferredValue(options.affinityIds);
   const effectiveOnly = useDeferredValue(options.effectiveOnly);
   const includeDLC = useDeferredValue(options.includeDLC);
+  const selectedWeapons = useDeferredValue(options.selectedWeapons);
 
   const specialUpgradeLevel = toSpecialUpgradeLevel(regularUpgradeLevel);
 
@@ -98,6 +101,10 @@ const useWeaponTableRows = ({
       includeDLC,
       twoHanding,
       uninfusableWeaponTypes,
+      selectedWeapons: selectedWeapons.reduce(
+        (acc, weapon) => (acc.add(weapon.value), acc),
+        new Set<string>(),
+      ),
     });
 
     const rows = filteredWeapons.map((weapon): WeaponTableRowData => {
@@ -143,6 +150,7 @@ const useWeaponTableRows = ({
     includeDLC,
     effectiveOnly,
     uninfusableWeaponTypes,
+    selectedWeapons,
   ]);
 
   const memoizedAttackPowerTypes = useMemo(


### PR DESCRIPTION
## Add Weapon Picker to Filters

Add the ability to filter by `weaponName`. One key decision that I made here that I'm happy to discuss is the ability for this to skill subsequent checks when the weapon is selected. At the moment, it will ignore the WeaponType filters if you've selected a specific weapon. This can make the UX a bit nicer, however it could be unexpected, and makes the filtering logic harder to reason about. It does however, allow the affinity filter to apply, so that you don't always see 10+ for every item you filter on.

![2024-08-26 15 28 44](https://github.com/user-attachments/assets/33731395-5ccf-4879-b4ec-cac3118fece5)
