### PR TITLE
Feature: Add Weapon Affinities to Favorites

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -107,6 +107,7 @@ export default function App() {
     attributes,
     includeDLC,
     effectiveOnly,
+    favoritesOnly,
     splitDamage,
     twoHanding,
     upgradeLevel,
@@ -115,12 +116,14 @@ export default function App() {
     sortBy,
     reverse,
     selectedWeapons,
+    favoriteWeapons,
     setRegulationVersionName,
     setAffinityIds,
     setWeaponTypes,
     setAttribute,
     setIncludeDLC,
     setEffectiveOnly,
+    setFavoritesOnly,
     setSplitDamage,
     setTwoHanding,
     setUpgradeLevel,
@@ -129,6 +132,7 @@ export default function App() {
     setSortBy,
     setReverse,
     setSelectedWeapons,
+    setFavoriteWeapons,
   } = useAppState();
 
   const { isMobile, menuOpen, menuOpenMobile, onMenuOpenChanged } = useMenuState();
@@ -152,10 +156,12 @@ export default function App() {
     attributes,
     includeDLC,
     effectiveOnly,
+    favoritesOnly,
     twoHanding,
     upgradeLevel,
     groupWeaponTypes,
     selectedWeapons,
+    favoriteWeapons,
   });
 
   const tablePlaceholder = useMemo(
@@ -198,6 +204,7 @@ export default function App() {
     mainContent = (
       <WeaponTable
         rowGroups={rowGroups}
+        favoriteWeapons={favoriteWeapons}
         placeholder={tablePlaceholder}
         footer={tableFooter}
         sortBy={sortBy}
@@ -209,6 +216,7 @@ export default function App() {
         spellScaling={spellScaling}
         onSortByChanged={setSortBy}
         onReverseChanged={setReverse}
+        onFavoriteChanged={setFavoriteWeapons}
       />
     );
   }
@@ -240,8 +248,10 @@ export default function App() {
         showIncludeDLC={showIncludeDLC}
         includeDLC={includeDLC}
         effectiveOnly={effectiveOnly}
+        favoritesOnly={favoritesOnly}
         onIncludeDLCChanged={setIncludeDLC}
         onEffectiveOnlyChanged={setEffectiveOnly}
+        onFavoritesOnlyChanged={setFavoritesOnly}
       />
       <WeaponPicker
         selectedWeapons={selectedWeapons}

--- a/src/app/MiscFilterPicker.tsx
+++ b/src/app/MiscFilterPicker.tsx
@@ -4,8 +4,10 @@ import { Checkbox, FormControlLabel } from "@mui/material";
 interface Props {
   showIncludeDLC: boolean;
   effectiveOnly: boolean;
+  favoritesOnly: boolean;
   includeDLC: boolean;
   onEffectiveOnlyChanged(effectiveOnly: boolean): void;
+  onFavoritesOnlyChanged(favoritesOnly: boolean): void;
   onIncludeDLCChanged(includeDLC: boolean): void;
 }
 
@@ -15,8 +17,10 @@ interface Props {
 function MiscFilterPicker({
   showIncludeDLC,
   effectiveOnly,
+  favoritesOnly,
   includeDLC,
   onEffectiveOnlyChanged,
+  onFavoritesOnlyChanged,
   onIncludeDLCChanged,
 }: Props) {
   return (
@@ -44,6 +48,18 @@ function MiscFilterPicker({
             checked={effectiveOnly}
             name="Effective only"
             onChange={(evt) => onEffectiveOnlyChanged(evt.currentTarget.checked)}
+          />
+        }
+      />
+      <FormControlLabel
+        label="Favorites only"
+        sx={{ display: "block", mr: 0, my: "-4px" }}
+        control={
+          <Checkbox
+            size="small"
+            checked={favoritesOnly}
+            name="Favorites only"
+            onChange={(evt) => onFavoritesOnlyChanged(evt.currentTarget.checked)}
           />
         }
       />

--- a/src/app/useAppState.ts
+++ b/src/app/useAppState.ts
@@ -15,12 +15,14 @@ interface AppState {
   readonly affinityIds: readonly number[];
   readonly includeDLC: boolean;
   readonly effectiveOnly: boolean;
+  readonly favoritesOnly: boolean;
   readonly splitDamage: boolean;
   readonly groupWeaponTypes: boolean;
   readonly numericalScaling: boolean;
   readonly sortBy: SortBy;
   readonly reverse: boolean;
   readonly selectedWeapons: WeaponOption[];
+  readonly favoriteWeapons: string[];
 }
 
 interface UpdateAppState extends AppState {
@@ -32,12 +34,14 @@ interface UpdateAppState extends AppState {
   setAffinityIds(affinityIds: readonly number[]): void;
   setIncludeDLC(includeDLC: boolean): void;
   setEffectiveOnly(effectiveOnly: boolean): void;
+  setFavoritesOnly(favoritesOnly: boolean): void;
   setSplitDamage(splitDamage: boolean): void;
   setGroupWeaponTypes(groupWeaponTypes: boolean): void;
   setNumericalScaling(numericalScaling: boolean): void;
   setSortBy(sortBy: SortBy): void;
   setReverse(reverse: boolean): void;
   setSelectedWeapons(weapons: WeaponOption[]): void;
+  setFavoriteWeapons(weapons: string[]): void;
 }
 
 const defaultAppState: AppState = {
@@ -55,12 +59,14 @@ const defaultAppState: AppState = {
   affinityIds: [0, -1], // Standard and Special
   includeDLC: true,
   effectiveOnly: false,
+  favoritesOnly: false,
   splitDamage: true,
   groupWeaponTypes: false,
   numericalScaling: false,
   sortBy: "totalAttack",
   reverse: false,
   selectedWeapons: [],
+  favoriteWeapons: [],
 };
 
 /**
@@ -159,6 +165,9 @@ export default function useAppState() {
       setEffectiveOnly(effectiveOnly) {
         setAppState((prevAppState) => ({ ...prevAppState, effectiveOnly }));
       },
+      setFavoritesOnly(favoritesOnly: boolean) {
+        setAppState((prevAppState) => ({ ...prevAppState, favoritesOnly }));
+      },
       setSplitDamage(splitDamage) {
         setAppState((prevAppState) => ({ ...prevAppState, splitDamage }));
       },
@@ -176,6 +185,9 @@ export default function useAppState() {
       },
       setSelectedWeapons(selectedWeapons) {
         setAppState((prevAppState) => ({ ...prevAppState, selectedWeapons }));
+      },
+      setFavoriteWeapons(weapons: string[]) {
+        setAppState((prevAppState) => ({ ...prevAppState, favoriteWeapons: weapons }));
       },
     }),
     [],

--- a/src/app/weaponTable/WeaponTable.tsx
+++ b/src/app/weaponTable/WeaponTable.tsx
@@ -19,8 +19,16 @@ import {
   WeaponTableGroup,
   WeaponTableGroupHeaderRow,
 } from "./tableStyledComponents";
+import type { FavoriteRendererProps } from "./tableRenderers";
+
+export type WeaponTableHeaderProps = {
+  shownWeapons: Weapon[],
+  favoriteWeapons: string[],
+  onFavoriteChange(weapons: Weapon[], favorite: boolean): void,
+};
 
 export type WeaponTableRowData = [Weapon, WeaponAttackResult];
+export type WeaponTableRendererProps = [...WeaponTableRowData, boolean, FavoriteRendererProps['onChange']];
 
 export interface WeaponTableRowGroup {
   key: string;
@@ -31,8 +39,8 @@ export interface WeaponTableRowGroup {
 export interface WeaponTableColumnDef {
   key: string;
   sortBy?: SortBy;
-  header: ReactNode;
-  render(row: WeaponTableRowData): ReactNode;
+  header(props: WeaponTableHeaderProps): ReactNode;
+  render(props: WeaponTableRendererProps): ReactNode;
   sx?: SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>);
 }
 
@@ -45,6 +53,7 @@ export interface WeaponTableColumnGroupDef {
 
 interface Props {
   rowGroups: readonly WeaponTableRowGroup[];
+  favoriteWeapons: string[];
   placeholder?: ReactNode;
   footer?: ReactNode;
   sortBy: SortBy;
@@ -77,6 +86,7 @@ interface Props {
 
   onSortByChanged(sortBy: SortBy): void;
   onReverseChanged(reverse: boolean): void;
+  onFavoriteChanged(weapons: string[]): void;
 }
 
 /**
@@ -84,16 +94,22 @@ interface Props {
  */
 const ColumnHeaderRow = memo(function ColumnHeaderRow({
   columnGroups,
+  shownWeapons,
+  favoriteWeapons,
   sortBy,
   reverse,
   onSortByChanged,
   onReverseChanged,
+  onFavoriteChanged,
 }: {
   columnGroups: readonly WeaponTableColumnGroupDef[];
+  shownWeapons: Weapon[],
+  favoriteWeapons: string[],
   sortBy: SortBy;
   reverse: boolean;
   onSortByChanged(sortBy: SortBy): void;
   onReverseChanged(reverse: boolean): void;
+  onFavoriteChanged(weapons: string[]): void;
 }) {
   const onColumnClicked = (column: WeaponTableColumnDef) => {
     if (column.sortBy) {
@@ -104,6 +120,18 @@ const ColumnHeaderRow = memo(function ColumnHeaderRow({
         onReverseChanged(false);
       }
     }
+  };
+
+  const handleFavoriteChanged = (weapons: Weapon[], favorite: boolean): void => {
+    const favorites = new Set(favoriteWeapons);
+
+    if (favorite) {
+      weapons.map((weapon) => favorites.add(weapon.name));
+    } else {
+      weapons.map((weapon) => favorites.delete(weapon.name));
+    }
+
+    onFavoriteChanged([...favorites]);
   };
 
   return (
@@ -150,7 +178,7 @@ const ColumnHeaderRow = memo(function ColumnHeaderRow({
                   : undefined
               }
             >
-              {column.header}
+              {column.header({ shownWeapons, favoriteWeapons, onFavoriteChange: handleFavoriteChanged })}
               {column.sortBy === sortBy &&
                 (reverse ? (
                   <ArrowDropUpIcon sx={{ justifySelf: "center" }} fontSize="small" />
@@ -173,7 +201,7 @@ const DataRow = memo(function DataRow({
   row,
 }: {
   columnGroups: readonly WeaponTableColumnGroupDef[];
-  row: WeaponTableRowData;
+  row: WeaponTableRendererProps;
 }) {
   return (
     <WeaponTableDataRow role="row">
@@ -192,6 +220,7 @@ const DataRow = memo(function DataRow({
 
 function WeaponTable({
   rowGroups,
+  favoriteWeapons,
   placeholder,
   footer,
   sortBy,
@@ -203,6 +232,7 @@ function WeaponTable({
   spellScaling,
   onSortByChanged,
   onReverseChanged,
+  onFavoriteChanged,
 }: Props) {
   const columnGroups = useMemo(
     () =>
@@ -215,6 +245,18 @@ function WeaponTable({
       }),
     [splitDamage, splitSpellScaling, numericalScaling, attackPowerTypes, spellScaling],
   );
+
+  const shownWeapons = rowGroups.flatMap(({ rows }) => rows.map(([weapon]) => weapon));
+
+  const handleFavoriteChanged = (weapon: Weapon, favorite: boolean): void => {
+    if (favorite) {
+      onFavoriteChanged([...favoriteWeapons, weapon.name]);
+    } else {
+      onFavoriteChanged(favoriteWeapons.filter((name) => name !== weapon.name));
+    }
+  };
+
+  const isWeaponFavorite = (weapon: Weapon): boolean => favoriteWeapons.includes(weapon.name);
 
   return (
     <ScrollArea.Root asChild>
@@ -237,10 +279,13 @@ function WeaponTable({
 
           <ColumnHeaderRow
             columnGroups={columnGroups}
+            shownWeapons={shownWeapons}
+            favoriteWeapons={favoriteWeapons}
             sortBy={sortBy}
             reverse={reverse}
             onSortByChanged={onSortByChanged}
             onReverseChanged={onReverseChanged}
+            onFavoriteChanged={onFavoriteChanged}
           />
           {rowGroups.length > 0 ? (
             rowGroups.map(({ key, name, rows }) => (
@@ -257,7 +302,7 @@ function WeaponTable({
                   <DataRow
                     key={`${row[0].weaponName},${row[0].affinityId}`}
                     columnGroups={columnGroups}
-                    row={row}
+                    row={[...row, isWeaponFavorite(row[0]), handleFavoriteChanged]}
                   />
                 ))}
               </WeaponTableGroup>

--- a/src/app/weaponTable/getWeaponTableColumns.tsx
+++ b/src/app/weaponTable/getWeaponTableColumns.tsx
@@ -13,18 +13,20 @@ import {
   getShortAttributeLabel,
   getTotalDamageAttackPower,
 } from "../uiUtils";
-import type { WeaponTableColumnDef, WeaponTableColumnGroupDef } from "./WeaponTable";
+import type { WeaponTableColumnDef, WeaponTableColumnGroupDef, WeaponTableHeaderProps } from "./WeaponTable";
 import {
   WeaponNameRenderer,
   ScalingRenderer,
   AttributeRequirementRenderer,
   AttackPowerRenderer,
+  FavoriteRenderer,
+  FavoriteHeader,
 } from "./tableRenderers";
 
 const nameColumn: WeaponTableColumnDef = {
   key: "name",
   sortBy: "name",
-  header: (
+  header: () => (
     <Typography component="span" variant="subtitle2">
       Weapon
     </Typography>
@@ -43,7 +45,7 @@ const attackColumns = Object.fromEntries(
     {
       key: `${attackPowerType}Attack`,
       sortBy: `${attackPowerType}Attack`,
-      header: damageTypeIcons.has(attackPowerType) ? (
+      header: () => damageTypeIcons.has(attackPowerType) ? (
         <img
           src={damageTypeIcons.get(attackPowerType)!}
           alt={damageTypeLabels.get(attackPowerType)!}
@@ -71,7 +73,7 @@ const attackColumns = Object.fromEntries(
 const splitSpellScalingColumns: WeaponTableColumnDef[] = allDamageTypes.map((damageType) => ({
   key: `${damageType}SpellScaling`,
   sortBy: `${damageType}SpellScaling`,
-  header: damageTypeIcons.has(damageType) ? (
+  header: () => damageTypeIcons.has(damageType) ? (
     <img
       src={damageTypeIcons.get(damageType)!}
       alt={damageTypeLabels.get(damageType)!}
@@ -97,7 +99,7 @@ const splitSpellScalingColumns: WeaponTableColumnDef[] = allDamageTypes.map((dam
 const spellScalingColumn: WeaponTableColumnDef = {
   key: "spellScaling",
   sortBy: `${AttackPowerType.MAGIC}SpellScaling`,
-  header: (
+  header: () => (
     <Typography component="span" variant="subtitle2">
       Spell scaling
     </Typography>
@@ -124,7 +126,7 @@ const spellScalingColumn: WeaponTableColumnDef = {
 const totalSplitAttackPowerColumn: WeaponTableColumnDef = {
   key: "totalAttack",
   sortBy: "totalAttack",
-  header: (
+  header: () => (
     <Typography component="span" variant="subtitle2">
       Total
     </Typography>
@@ -144,7 +146,7 @@ const totalSplitAttackPowerColumn: WeaponTableColumnDef = {
 const totalAttackPowerColumn: WeaponTableColumnDef = {
   key: "totalAttack",
   sortBy: "totalAttack",
-  header: (
+  header: () => (
     <Typography component="span" variant="subtitle2">
       Attack Power
     </Typography>
@@ -164,7 +166,7 @@ const totalAttackPowerColumn: WeaponTableColumnDef = {
 const scalingColumns: WeaponTableColumnDef[] = allAttributes.map((attribute) => ({
   key: `${attribute}Scaling`,
   sortBy: `${attribute}Scaling`,
-  header: (
+  header: () => (
     <Typography
       component="span"
       variant="subtitle2"
@@ -181,7 +183,7 @@ const scalingColumns: WeaponTableColumnDef[] = allAttributes.map((attribute) => 
 const numericalScalingColumns: WeaponTableColumnDef[] = allAttributes.map((attribute) => ({
   key: `${attribute}Scaling`,
   sortBy: `${attribute}Scaling`,
-  header: (
+  header: () => (
     <Typography
       component="span"
       variant="subtitle2"
@@ -202,11 +204,25 @@ const numericalScalingColumns: WeaponTableColumnDef[] = allAttributes.map((attri
   },
 }));
 
+const favoriteColumn: WeaponTableColumnDef = {
+  key: "favorite",
+  header({ shownWeapons, favoriteWeapons, onFavoriteChange }: WeaponTableHeaderProps) {
+    return (
+      <FavoriteHeader shownWeapons={shownWeapons} favoriteWeapons={favoriteWeapons} onChange={onFavoriteChange} />
+    );
+  },
+  render([weapon, , favorite, onFavoriteChange]) {
+    return (
+      <FavoriteRenderer weapon={weapon} checked={favorite} onChange={onFavoriteChange} />
+    );
+  },
+};
+
 const requirementColumns = allAttributes.map(
   (attribute): WeaponTableColumnDef => ({
     key: `${attribute}Requirement`,
     sortBy: `${attribute}Requirement`,
-    header: (
+    header: () => (
       <Typography
         component="span"
         variant="subtitle2"
@@ -322,5 +338,13 @@ export default function getWeaponTableColumns({
       header: "Attributes Required",
       columns: requirementColumns,
     },
+    {
+      key: "favorite",
+      sx: {
+        width: 72,
+      },
+      header: 'Favorite',
+      columns: [favoriteColumn],
+    }
   ];
 }

--- a/src/app/weaponTable/tableRenderers.tsx
+++ b/src/app/weaponTable/tableRenderers.tsx
@@ -5,11 +5,12 @@
  * of the table does, so it's performant to be able to skip over them when e.g. only attack
  * power changes.
  */
-import { memo } from "react";
-import { Box, Link, Typography } from "@mui/material";
+import { memo, useMemo } from "react";
+import { Box, Checkbox, type CheckboxProps, Link, Typography } from "@mui/material";
 import RemoveIcon from "@mui/icons-material/Remove";
 import { type Weapon, type Attribute } from "../../calculator/calculator";
 import { getAttributeLabel } from "../uiUtils";
+import { Favorite, FavoriteBorder } from "@mui/icons-material";
 
 export const blankIcon = <RemoveIcon color="disabled" fontSize="small" />;
 
@@ -137,4 +138,46 @@ export const AttackPowerRenderer = memo(function AttackPowerRenderer({
   }
 
   return <>{round(value)}</>;
+});
+
+export type FavoriteHeaderProps = {
+  shownWeapons: Weapon[];
+  favoriteWeapons: string[];
+  onChange: (weapons: Weapon[], favorite: boolean) => void;
+};
+
+export const FavoriteHeader = memo(function FavoriteHeader({
+  shownWeapons,
+  favoriteWeapons,
+  onChange,
+}: FavoriteHeaderProps) {
+  const { all, some } = useMemo(() => {
+    const shownWeaponNames = shownWeapons.map((weapon) => weapon.name);
+    const all = shownWeaponNames.length > 0 && shownWeaponNames.every((name) => favoriteWeapons.includes(name));
+
+    return {
+      all,
+      some: !all && shownWeaponNames.some((name) => favoriteWeapons.includes(name)),
+    };
+  }, [shownWeapons, favoriteWeapons]);
+
+  const handleChange: CheckboxProps['onChange'] = (_, checked) => {
+    onChange(shownWeapons, checked);
+  }
+
+  return <Checkbox checked={all} indeterminate={some} onChange={handleChange} />;
+});
+
+export type FavoriteRendererProps = {
+  weapon: Weapon;
+  checked: boolean;
+  onChange: (weapon: Weapon, favorite: boolean) => void;
+};
+
+export const FavoriteRenderer = memo(function FavoriteRenderer({ weapon, checked, onChange }: FavoriteRendererProps) {
+  const handleChange: CheckboxProps['onChange'] = (_, checked) => {
+    onChange(weapon, checked);
+  };
+
+  return <Checkbox icon={<FavoriteBorder />} checkedIcon={<Favorite />} checked={checked} onChange={handleChange} />
 });

--- a/src/app/weaponTable/useWeaponTableRows.tsx
+++ b/src/app/weaponTable/useWeaponTableRows.tsx
@@ -30,10 +30,12 @@ interface WeaponTableRowsOptions {
   attributes: Attributes;
   includeDLC: boolean;
   effectiveOnly: boolean;
+  favoritesOnly: boolean;
   twoHanding: boolean;
   upgradeLevel: number;
   groupWeaponTypes: boolean;
   selectedWeapons: WeaponOption[];
+  favoriteWeapons: string[];
 }
 
 interface WeaponTableRowsResult {
@@ -69,8 +71,10 @@ const useWeaponTableRows = ({
   const weaponTypes = useDeferredValue(options.weaponTypes);
   const affinityIds = useDeferredValue(options.affinityIds);
   const effectiveOnly = useDeferredValue(options.effectiveOnly);
+  const favoritesOnly = useDeferredValue(options.favoritesOnly);
   const includeDLC = useDeferredValue(options.includeDLC);
   const selectedWeapons = useDeferredValue(options.selectedWeapons);
+  const favoriteWeapons = useDeferredValue(options.favoriteWeapons);
 
   const specialUpgradeLevel = toSpecialUpgradeLevel(regularUpgradeLevel);
 
@@ -98,6 +102,7 @@ const useWeaponTableRows = ({
         affinityIds.filter((affinityId) => regulationVersion.affinityOptions.has(affinityId)),
       ),
       effectiveWithAttributes: effectiveOnly ? attributes : undefined,
+      favoritesOnly,
       includeDLC,
       twoHanding,
       uninfusableWeaponTypes,
@@ -105,6 +110,7 @@ const useWeaponTableRows = ({
         (acc, weapon) => (acc.add(weapon.value), acc),
         new Set<string>(),
       ),
+      favoriteWeapons: new Set(favoriteWeapons),
     });
 
     const rows = filteredWeapons.map((weapon): WeaponTableRowData => {
@@ -149,8 +155,10 @@ const useWeaponTableRows = ({
     affinityIds,
     includeDLC,
     effectiveOnly,
+    favoritesOnly,
     uninfusableWeaponTypes,
     selectedWeapons,
+    favoriteWeapons,
   ]);
 
   const memoizedAttackPowerTypes = useMemo(


### PR DESCRIPTION
A new feature has been implemented that allows users to add individual weapon affinities to their favorites.

Currently, the project offers a weapon search feature where users can specify multiple weapon names to display them in a table. Searching by a specific weapon name returns a list of all its affinities. However, this method has some limitations:

- There is no quick way to toggle filters for weapon names while keeping the selected values intact.
- Users cannot isolate specific affinities in the results. Combining affinity and weapon name filters doesn’t fully solve this issue. For example, if a user wants to compare the Magic Grave Scythe and Magic Stone Club, applying both filters results in extra, unwanted items in the list. The more weapons included in the search, the more irrelevant entries appear in the results.

From my own experience (I’m currently playing the game), it would be helpful to add individual weapon affinities to a favorites list. To address this, I’ve implemented a feature that allows users to do just that.

A new column, Favorites, has been added to the weapon table. Each row now contains a checkbox that allows users to add individual weapons to their favorites.

At the top of the table, there’s a three-state checkbox (checked, indeterminate, unchecked). When unchecked or indeterminate, clicking the checkbox adds all visible weapons on the page to the favorites list. When checked, clicking the checkbox removes all visible weapons from the favorites list.

A new Favorites only checkbox has been added to the sidebar filters. When checked, only favorited weapons will be displayed. This filter works seamlessly with other filters. For example, if the Weapons field contains values, the favorites filter will apply to those results first. If the Weapons field is empty, the favorites filter will take precedence over the Weapons type filter. Additionally, filters like Include DLC weapons, Effective only, and Affinity will refine the favorites list accordingly.

This makes it easy to toggle between a favorites list and the full weapon list, as well as to mass add or remove weapons based on filter criteria.

### Implementation Notes:

1. It was challenging to pass additional data to the row renderer. I had to extend the accepted tuple to pass the favorite flag and the onFavoriteChange handler. This could have been resolved using the useAppState hook in the checkbox component, but I couldn’t due to the hook’s limitations.
2. I had to refactor the header field in the WeaponTableColumnDef type into a function, similar to how the render function works, to handle clicks on the header checkbox.

Lastly, as a backend developer, I acknowledge that the UI design for this feature isn’t perfect. If this feature is accepted, I’m open to working with the community to refine the user interface to an acceptable standard.